### PR TITLE
skip_on_cran() parallel code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,9 +6,19 @@ Version: 2.0.7
 Date: 2021-02-10
 License: GPL-3
 Authors@R: c(
- person("Leonel", "Herrera Alsina", email = "leonelhalsina@gmail.com", role = "cre"),
- person("Paul", "van Els", email = "paulvanels@gmail.com", role = "aut"),
- person("Rampal", "Etienne", email = "r.s.etienne@rug.nl", role = "aut"))
+ person(given = "Leonel",
+        family = "Herrera Alsina",
+        email = "leonelhalsina@gmail.com",
+        role = "aut"),
+ person(given = "Paul",
+        family = "van Els",
+        email = "paulvanels@gmail.com",
+        role = "aut"),
+ person(given = "Rampal S.",
+        family = "Etienne",
+        email = "r.s.etienne@rug.nl",
+        role = c("cre","aut"),
+        comment = c(ORCID = "0000-0003-2142-7612")))
 Description: Simultaneously infers state-dependent diversification across
  two or more states of a single or multiple traits while accounting for the
  role of a possible concealed trait. See Herrera-Alsina et al. 2019

--- a/tests/testthat/test_secsse.R
+++ b/tests/testthat/test_secsse.R
@@ -102,8 +102,14 @@ test_that("secsse gives the same result as hisse", {
                                  root_state_weight = root_state_weight,
                                  sampling_fraction = sampling_fraction,
                                  func = "secsse_runmod"))
+  
+  testthat::expect_equal(-237.8611,y1)##-237.8611 is the right one, 
+  testthat::expect_equal(-243.8611,y2)
+  testthat::expect_equal(z1, z2) 
+  testthat::expect_equal(z2, z3) 
   # Parallel code doesn't work on CI unless running on windows
   if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
+    skip_on_cran()
     z4 <- as.numeric(secsse_loglik(parameter = toCheck,
                                    phy = phy,
                                    traits = traits,
@@ -117,11 +123,6 @@ test_that("secsse gives the same result as hisse", {
                                    run_parallel = TRUE))
     testthat::expect_equal(z3, z4)
   }
-  
-  testthat::expect_equal(-237.8611,y1)##-237.8611 is the right one, 
-  testthat::expect_equal(-243.8611,y2)
-  testthat::expect_equal(z1, z2) 
-  testthat::expect_equal(z2, z3) 
 })
 
 test_that("secsse gives the same result as GeoSSE", {
@@ -213,6 +214,7 @@ test_that("secsse gives the same result as GeoSSE", {
   
   # Parallel code doesn't work on CI unless running on windows
   if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
+    skip_on_cran()
     secsse_cla_LL3 <- cla_secsse_loglik(parameter,
                                         phy,
                                         traits,
@@ -236,6 +238,7 @@ test_that("trying a short ML search: secsse_ml & parallel procedure", {
     isTRUE(as.logical(Sys.getenv("CI"))) && !.Platform$OS.type == "windows",
     message = "Parallel code doesn't work on CI unless running on windows"
   )
+  skip_on_cran()
   
   Sys.unsetenv("R_TESTS")
   parenthesis <- "(((6:0.2547423371,(1:0.0496153503,4:0.0496153503):0.2051269868):0.1306304758,(9:0.2124135406,5:0.2124135406):0.1729592723):1.151205247,(((7:0.009347664296,3:0.009347664296):0.2101416075,10:0.2194892718):0.1035186448,(2:0.2575886319,8:0.2575886319):0.06541928469):1.213570144);"
@@ -561,22 +564,6 @@ test_that("the loglik for the complete tree", {
                                               func = "secsse_runmod_ct"))
   testthat::expect_equal(loglik5,-298.3583,tolerance = 1E-4)
   
-  # Parallel code doesn't work on CI unless running on windows
-  if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
-    loglik6 <- as.numeric(secsse::secsse_loglik(parameter = toCheck,
-                                                phy = phy,
-                                                traits = traits,
-                                                num_concealed_states = num_concealed_states,
-                                                use_fortran = TRUE,
-                                                run_parallel = TRUE,
-                                                methode = "ode45",
-                                                cond = cond,
-                                                root_state_weight = root_state_weight,
-                                                sampling_fraction = sampling_fraction,
-                                                is_complete_tree = TRUE,
-                                                func = "secsse_runmod_ct"))
-    testthat::expect_equal(loglik6,loglik5,tolerance = 1E-4)
-  }
   lambdas <- list()
   for(i in 1:4) {
     lambdas[[i]] <- matrix(0,ncol = 4,nrow = 4,byrow = TRUE)
@@ -605,6 +592,21 @@ test_that("the loglik for the complete tree", {
   
   # Parallel code doesn't work on CI unless running on windows
   if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
+    skip_on_cran()
+    loglik6 <- as.numeric(secsse::secsse_loglik(parameter = toCheck,
+                                                phy = phy,
+                                                traits = traits,
+                                                num_concealed_states = num_concealed_states,
+                                                use_fortran = TRUE,
+                                                run_parallel = TRUE,
+                                                methode = "ode45",
+                                                cond = cond,
+                                                root_state_weight = root_state_weight,
+                                                sampling_fraction = sampling_fraction,
+                                                is_complete_tree = TRUE,
+                                                func = "secsse_runmod_ct"))
+    testthat::expect_equal(loglik6,loglik5,tolerance = 1E-4)
+    
     loglik8 <- secsse::cla_secsse_loglik(parameter = parameter,
                                          phy = phy,
                                          traits = traits,
@@ -689,8 +691,8 @@ test_that("the loglik for the complete tree under cla_secsse", {
                                       is_complete_tree = TRUE)
   testthat::expect_equal(secsse_cla_LL3,secsse_cla_LL4)
   
-  # Parallel code doesn't work on CI unless running on windows
   if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
+    skip_on_cran()
     secsse_cla_LL5 <- cla_secsse_loglik(parameter = parameter,
                                         phy = phy,
                                         traits = traits,
@@ -708,6 +710,7 @@ test_that("the loglik for the complete tree under cla_secsse", {
                                         is_complete_tree = TRUE)
     testthat::expect_equal(secsse_cla_LL5,secsse_cla_LL4)
   }
+  
   parameter[[2]] <- rep(0.04,9)  
   setting_calculation <- 
     build_initStates_time(phy, traits, num_concealed_states, sampling_fraction = sampling_fraction, is_complete_tree = TRUE, mus = parameter[[2]])
@@ -730,6 +733,8 @@ test_that("the loglik for the complete tree under cla_secsse", {
     build_initStates_time_bigtree(phy, traits, num_concealed_states, sampling_fraction, is_complete_tree = TRUE, mus = parameter[[2]])
   # Parallel code doesn't work on CI unless running on windows
   if (!isTRUE(as.logical(Sys.getenv("CI"))) || .Platform$OS.type == "windows") {
+    skip_on_cran()
+    
     secsse_cla_LL5a <- cla_secsse_loglik(parameter = parameter,
                                          phy = phy,
                                          traits = traits,


### PR DESCRIPTION
Skips tests that run parallel functions when on CRAN