### PR TITLE
v3.0.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,55 +1,53 @@
 {
-  "title": "secsse: Several Examined and Concealed States-Dependent Speciation and Extinction",
-  "license": "GPL-3.0",
-  "upload_type": "software",
-  "description": "<p>SecSSE is an R package designed for multistate data sets under a concealed state and speciation (hisse) framework. In this sense, it is parallel to the 'MuSSE' functionality implemented in diversitree, but it accounts for finding possible spurious relationships between traits and diversification rates ('false positives', Rabosky & Goldberg 2015) by testing against a 'hidden trait' (Beaulieu et al. 2013), which is responsible for more variation in diversification rates than the trait being investigated. <\/p>",
-  "keywords": [
-    "Evolving traits",
-    "macroevolution",
-    "phylogenetic tools",
-    "speciation rates",
-    "model",
-    "maximum-likelihood",
-    "parameter estimation"
-  ],
-  "access_right": "open",
-  "language": "eng",
-  "contributors": [
-    {
-      "name": "Janzen, Thijs",
-      "affiliation": "University of Groningen",
-      "orcid": "0000-0002-4162-1140",
-      "type": "ProjectMember"
-    },
-    {
-      "name": "Hildenbrandt, Hanno",
-      "affiliation": "University of Groningen",
-      "orcid": "0000-0002-6784-1037",
-      "type": "ProjectMember"
-    },
-    {
-      "name": "Santos Neves, Pedro",
-      "affiliation": "University of Groningen",
-      "orcid": "0000-0003-2561-4677",
-      "type": "ProjectMember"
-    }
-  ],
-  "creators": [
-    {
-      "name": "Herrera Alsina, Leonel",
-      "affiliation": "University of Aberdeen",
-      "orcid": "0000-0003-0474-3592",
-    },
-    {
-      "name": "van Els, Paul",
-      "affiliation": "Sovon Dutch Centre for Field Ornithology",
-      "orcid": "0000-0002-9499-8873",
-    },
-    {
-      "name": "Etienne, Rampal S.",
-      "affiliation": "University of Groningen",
-      "orcid": "0000-0003-2142-7612",
-    },
-  ], 
-    "notes": "Compiled code (*.cpp and *.h files) is licensed under the BSL-1.0. See file COPYRIGHTS and LICENSE.note for mode details",
+	"title": "secsse: Several Examined and Concealed States-Dependent Speciation and Extinction",
+	"license": "GPL-3.0",
+	"upload_type": "software",
+	"description": "<p>SecSSE is an R package designed for multistate data sets under a concealed state and speciation (hisse) framework. In this sense, it is parallel to the 'MuSSE' functionality implemented in diversitree, but it accounts for finding possible spurious relationships between traits and diversification rates ('false positives', Rabosky & Goldberg 2015) by testing against a 'hidden trait' (Beaulieu et al. 2013), which is responsible for more variation in diversification rates than the trait being investigated. <\/p>",
+	"keywords": [
+		"Evolving traits",
+		"macroevolution",
+		"phylogenetic tools",
+		"speciation rates",
+		"model",
+		"maximum-likelihood",
+		"parameter estimation"
+	],
+	"access_right": "open",
+	"language": "eng",
+	"contributors": [{
+			"name": "Janzen, Thijs",
+			"affiliation": "University of Groningen",
+			"orcid": "0000-0002-4162-1140",
+			"type": "ProjectMember"
+		},
+		{
+			"name": "Hildenbrandt, Hanno",
+			"affiliation": "University of Groningen",
+			"orcid": "0000-0002-6784-1037",
+			"type": "ProjectMember"
+		},
+		{
+			"name": "Santos Neves, Pedro",
+			"affiliation": "University of Groningen",
+			"orcid": "0000-0003-2561-4677",
+			"type": "ProjectMember"
+		}
+	],
+	"creators": [{
+			"name": "Herrera Alsina, Leonel",
+			"affiliation": "University of Aberdeen",
+			"orcid": "0000-0003-0474-3592"
+		},
+		{
+			"name": "van Els, Paul",
+			"affiliation": "Sovon Dutch Centre for Field Ornithology",
+			"orcid": "0000-0002-9499-8873"
+		},
+		{
+			"name": "Etienne, Rampal S.",
+			"affiliation": "University of Groningen",
+			"orcid": "0000-0003-2142-7612"
+		}
+	],
+	"notes": "Compiled code (*.cpp and *.h files) is licensed under the BSL-1.0. See file COPYRIGHTS and LICENSE.note for mode details"
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Several Examined and Concealed States-Dependent Speciation and
  Extinction
 Version: 3.0.1
-Date: 2023-07-27
+Date: 2023-09-29
 License: GPL (>= 3) | file LICENSE
 Authors@R: c(
  person(given = "Leonel",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: secsse
 Type: Package
 Title: Several Examined and Concealed States-Dependent Speciation and
  Extinction
-Version: 3.0.0
+Version: 3.0.1
 Date: 2023-07-27
 License: GPL (>= 3) | file LICENSE
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,92 +1,137 @@
-# secsse 3.0.0
+---
+editor_options: 
+  markdown: 
+    wrap: 72
+---
 
-Version 3.0.0 extends the C++ code base used for the standard likelihood to the "cla_"
-likelihood, harnessing the same computation improvement. 
+# secsse 3.0.1
+
+Version 3.0.1 patches some inaccuracies in simulation functions, and
+deprecates expand_q_matrix, as this was making some incorrect
+assumptions.
 
 ## Breaking changes
-* Function name changes:
-    * `create_lambda_matrices()` is now called `create_lambda_list()`
-    * `create_transition_matrix()` is now called `create_q_matrix()`
-    * `create_mus()` is now called `create_mu_vector()`
-    * `create_default_q_list()` is now called `create_default_shift_matrix()`
-    * `create_default_lambda_list ()` is now called `create_default_lambda_transition_matrix()`
-    * `create_default_q_list()` is now called `create_default_shift_matrix()`
-* Package data files renamed: 
-    * `phylo_Vign` is now called `phylo_vignette`
-    * `traitinfo` is now called `traits`
-    * `phy` is now called `example_phy_GeoSSE`
-* `plot_state_exact()` argument `steps` renamed to `num_steps` and argument 
-`focal_tree` renamed to `phy` for consistency with other functions.
+
+-   The function expand_q_matrix is now deprecated, please use
+    q_doubletrans
+
+## Minor changes
+
+-   Added conditioning of simulation of complete trees on complete tree
+    size
+-   Fixed some issues with setting `pool_init_states`
+-   Added option to return a histogram of simulated tree sizes, across
+    all successful and failed trees.
+
+# 3.0.0
+
+Version 3.0.0 extends the C++ code base used for the standard likelihood
+to the "cla\_" likelihood, harnessing the same computation improvement.
+
+## Breaking changes
+
+-   Function name changes:
+    -   `create_lambda_matrices()` is now called `create_lambda_list()`
+    -   `create_transition_matrix()` is now called `create_q_matrix()`
+    -   `create_mus()` is now called `create_mu_vector()`
+    -   `create_default_q_list()` is now called
+        `create_default_shift_matrix()`
+    -   `create_default_lambda_list ()` is now called
+        `create_default_lambda_transition_matrix()`
+    -   `create_default_q_list()` is now called
+        `create_default_shift_matrix()`
+-   Package data files renamed:
+    -   `phylo_Vign` is now called `phylo_vignette`
+    -   `traitinfo` is now called `traits`
+    -   `phy` is now called `example_phy_GeoSSE`
+-   `plot_state_exact()` argument `steps` renamed to `num_steps` and
+    argument `focal_tree` renamed to `phy` for consistency with other
+    functions.
 
 ## Major changes
 
-* Vastly improve the computational speed of "cla_" likelihood calculation.
-* Optimization of parallelization resulting in better scaling with more threads
-and faster run time for standard secsse and cla_secsse likelihood calculations.
+-   Vastly improve the computational speed of "cla\_" likelihood
+    calculation.
+-   Optimization of parallelization resulting in better scaling with
+    more threads and faster run time for standard secsse and cla_secsse
+    likelihood calculations.
 
 ## Minor changes
-* Added a `NEWS.md` file to track changes to the package.
-* Documentation reworked into `default_params_doc()`.
-* Several documentation formatting improvements and linking. Documentation now
-follows and allows for roxygen2 markdown.
-* A new vignette:
-    * _Using secsse with complete phylogenies (with extinction)_ `vignette("complete_tree", package = "secsse")`
-* A new [pkgdown website](https://rsetienne.github.io/secsse/index.html)! 
-    * It contains all the documentation and vignettes of the package, along with
-    additional interesting information like the _Secsse versions_ article with
-    details on performance and the development history of secsse.
-* Revise, combine and simplify the _Using SecSSE ML search_ and _Setting up a 
-secsse analysis_ into the _Starting secsse_ vignette 
-`vignette("starting_secsse", package = "secsse")`.
-* `secsse_sim()` argument `conditioning` now defaults to `"obs_states"` from 
-`"none"`.
-* No longer Import package 'stringr' and Suggest package 'testit'.
-* New organisation of code in .R, .cpp and .h files. (Developer side).
-* Start archiving in Zenodo, with new .zenodo.json metadata file.
+
+-   Added a `NEWS.md` file to track changes to the package.
+-   Documentation reworked into `default_params_doc()`.
+-   Several documentation formatting improvements and linking.
+    Documentation now follows and allows for roxygen2 markdown.
+-   A new vignette:
+    -   *Using secsse with complete phylogenies (with extinction)*
+        `vignette("complete_tree", package = "secsse")`
+-   A new [pkgdown
+    website](https://rsetienne.github.io/secsse/index.html)!
+    -   It contains all the documentation and vignettes of the package,
+        along with additional interesting information like the *Secsse
+        versions* article with details on performance and the
+        development history of secsse.
+-   Revise, combine and simplify the *Using SecSSE ML search* and
+    *Setting up a secsse analysis* into the *Starting secsse* vignette
+    `vignette("starting_secsse", package = "secsse")`.
+-   `secsse_sim()` argument `conditioning` now defaults to
+    `"obs_states"` from `"none"`.
+-   No longer Import package 'stringr' and Suggest package 'testit'.
+-   New organisation of code in .R, .cpp and .h files. (Developer side).
+-   Start archiving in Zenodo, with new .zenodo.json metadata file.
 
 ## Bug fixes
-* `secsse_sim()` fix bug causing error when simulating trees with extinct 
-species.
+
+-   `secsse_sim()` fix bug causing error when simulating trees with
+    extinct species.
 
 # 2.6.0
 
 ## Major changes
-* C++ code base for the standard likelihood, making smarter use of
-parallelization, this marks another 10-fold increase in speed.
+
+-   C++ code base for the standard likelihood, making smarter use of
+    parallelization, this marks another 10-fold increase in speed.
 
 ## Minor changes
-* Add a number of helper functions: `fill_in()`, `create_default_q_list()`, 
-`create_default_transition_list()`, `create_mus()`
-* Implemented necessary changes to comply with CRAN clang16 build and solve
-issue with the boost odeint library uninitialized variable 
-(see https://github.com/boostorg/odeint/issues/59 and more details at 
-https://github.com/rsetienne/DAISIE/pull/158)
-* Updated Copyright license to the Boost Software License, Version 1.0 for 
-included C++ code (R code remains GPL>=3).
+
+-   Add a number of helper functions: `fill_in()`,
+    `create_default_q_list()`, `create_default_transition_list()`,
+    `create_mus()`
+-   Implemented necessary changes to comply with CRAN clang16 build and
+    solve issue with the boost odeint library uninitialized variable
+    (see <https://github.com/boostorg/odeint/issues/59> and more details
+    at <https://github.com/rsetienne/DAISIE/pull/158>)
+-   Updated Copyright license to the Boost Software License, Version 1.0
+    for included C++ code (R code remains GPL\>=3).
 
 ## Bug fixes
-* Fix memory leaks
+
+-   Fix memory leaks
 
 # 2.5.0
-Version 2.5.0 appeared in 2021 on GitHub and was published in May 2023 on CRAN.
-Version 2.5.0 marks the first version using C++ to perform the integration,
-and it used tbb (from the RcppParallel package) to perform multithreading. This
-marks a ten fold increase in speed over previous versions.
-Secondly, 2.5.0 introduces the function `secsse_sim()` to simulate a 
-diversification process using the (cla) secsse framework.
-Lastly, in version 2.5.0 functions were added to allow visualisation of 
-inferred rates of speciation across the tree (e.g. `plot_state_exact()` and
-`secsse_loglik_eval()`).
+
+Version 2.5.0 appeared in 2021 on GitHub and was published in May 2023
+on CRAN. Version 2.5.0 marks the first version using C++ to perform the
+integration, and it used tbb (from the RcppParallel package) to perform
+multithreading. This marks a ten fold increase in speed over previous
+versions. Secondly, 2.5.0 introduces the function `secsse_sim()` to
+simulate a diversification process using the (cla) secsse framework.
+Lastly, in version 2.5.0 functions were added to allow visualisation of
+inferred rates of speciation across the tree (e.g. `plot_state_exact()`
+and `secsse_loglik_eval()`).
 
 # 2.0.0
-Version 2.0.0 appeared in June of 2019 on CRAN and extended the package with the
-cla framework, e.g. including state shifts during speciation / asymmetric 
-inheritance during speciation. 
+
+Version 2.0.0 appeared in June of 2019 on CRAN and extended the package
+with the cla framework, e.g. including state shifts during speciation /
+asymmetric inheritance during speciation.
 
 # 1.0.0
-The first version of secsse appeared in January of 2019 on CRAN. It used the
-package deSolve to solve all integrations, and could switch between either using
-a fully R based evaluation, or use FORTRAN to speed up calculations.
-Furthermore, using the foreach package, within-R parallelization was
-implemented. However, parallelization only situationally improved computation
-times, and generally, computation was relatively slow.
+
+The first version of secsse appeared in January of 2019 on CRAN. It used
+the package deSolve to solve all integrations, and could switch between
+either using a fully R based evaluation, or use FORTRAN to speed up
+calculations. Furthermore, using the foreach package, within-R
+parallelization was implemented. However, parallelization only
+situationally improved computation times, and generally, computation was
+relatively slow.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,3 @@
----
-editor_options: 
-  markdown: 
-    wrap: 72
----
-
 # secsse 3.0.1
 
 Version 3.0.1 patches some inaccuracies in simulation functions, and

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,9 @@ ct_condition_cpp <- function(rhs, state, t, lambdas, mus, Q, method, atol, rtol)
     .Call(`_secsse_ct_condition_cpp`, rhs, state, t, lambdas, mus, Q, method, atol, rtol)
 }
 
+#' 
+NULL
+
 secsse_sim_cpp <- function(m_R, lambdas_R, q_R, max_time, max_species, max_species_extant, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec, return_tree_size_hist) {
     .Call(`_secsse_secsse_sim_cpp`, m_R, lambdas_R, q_R, max_time, max_species, max_species_extant, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec, return_tree_size_hist)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,7 +13,7 @@ ct_condition_cpp <- function(rhs, state, t, lambdas, mus, Q, method, atol, rtol)
     .Call(`_secsse_ct_condition_cpp`, rhs, state, t, lambdas, mus, Q, method, atol, rtol)
 }
 
-secsse_sim_cpp <- function(m_R, lambdas_R, q_R, max_time, max_species, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec) {
-    .Call(`_secsse_secsse_sim_cpp`, m_R, lambdas_R, q_R, max_time, max_species, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec)
+secsse_sim_cpp <- function(m_R, lambdas_R, q_R, max_time, max_species, max_species_extant, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec, return_tree_size_hist) {
+    .Call(`_secsse_secsse_sim_cpp`, m_R, lambdas_R, q_R, max_time, max_species, max_species_extant, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec, return_tree_size_hist)
 }
 

--- a/R/default_params_doc.R
+++ b/R/default_params_doc.R
@@ -212,6 +212,11 @@ default_params_doc <- function(phy,
                                params,
                                param_posit,
                                ml_pars,
-                               mu_vector) {
+                               mu_vector,
+                               max_spec,
+                               min_spec,
+                               max_species_extant,
+                               tree_size_hist,
+                               optimmethod) {
   # Nothing
 }

--- a/R/default_params_doc.R
+++ b/R/default_params_doc.R
@@ -76,6 +76,9 @@
 #'  tree is not conditioned on this number, but that this is a safeguard 
 #'  against generating extremely large trees).
 #' @param min_spec Minimum number of species in the tree.
+#' @param max_species_extant Should the maximum number of species be counted in
+#' the reconstructed tree (if TRUE) or in the complete tree (if FALSE).
+#' @param tree_size_hist if TRUE, returns a vector of all found tree sizes. 
 #' @param conditioning can be `"obs_states"`, `"true_states"` or `"none"`, the 
 #'  tree is simulated until one is generated that contains all observed states
 #'  (`"obs_states"`), all true states (e.g. all combinations of obs and hidden

--- a/R/secsse_prep.R
+++ b/R/secsse_prep.R
@@ -207,9 +207,9 @@ get_chosen_rates <- function(q_matrix, num_concealed_states) {
   chosen_rates <- existing_rates
   while (num_transitions > length(chosen_rates)) {
     remain <- num_transitions - length(existing_rates)
-    to_add <- sample(existing_rates,
-                     size = min(remain, length(existing_rates)),
-                     replace = FALSE)
+    to_add <- DDD::sample2(x = existing_rates,
+                           size = min(remain, length(existing_rates)),
+                           replace = FALSE)
     chosen_rates <- c(chosen_rates, to_add)
   }
   return(chosen_rates)

--- a/R/secsse_prep.R
+++ b/R/secsse_prep.R
@@ -147,11 +147,15 @@ create_q_matrix <- function(state_names,
 
   diag(trans_matrix) <- NA
 
-  trans_matrix <- secsse::expand_q_matrix(q_matrix = trans_matrix,
-                                          num_concealed_states =
-                                            num_concealed_states,
-                                          diff.conceal = diff.conceal)
+  #trans_matrix <- secsse::expand_q_matrix(q_matrix = trans_matrix,
+  #                                        num_concealed_states =
+  #                                          num_concealed_states,
+  #                                        diff.conceal = diff.conceal)
 
+  trans_matrix <- secsse::q_doubletrans(traits = state_names,
+                                        masterBlock = trans_matrix,
+                                        diff.conceal = diff.conceal)
+  
   all_state_names <- get_state_names(state_names, num_concealed_states)
   colnames(trans_matrix) <- all_state_names
   rownames(trans_matrix) <- all_state_names
@@ -248,6 +252,7 @@ fill_from_rates <- function(new_q_matrix,
 expand_q_matrix <- function(q_matrix,
                             num_concealed_states,
                             diff.conceal = FALSE) {
+  stop("this function is deprecated. Please use q_doubletrans")
   num_traits <- ncol(q_matrix)
 
   # we first fill in the existing q matrix

--- a/R/secsse_sim.R
+++ b/R/secsse_sim.R
@@ -65,6 +65,17 @@ secsse_sim <- function(lambdas,
     # now we have to match the indices
     all_states <- names(mus)
     indices <- which(all_states %in% pool_init_states)
+    if (length(indices) < 1) {
+      # most likely states without hidden labels have been provided
+      letters_conceal <- LETTERS[1:num_concealed_states]
+      all_states2 <- c()
+      for (i in 1:length(pool_init_states)) {
+        for (j in 1:length(letters_conceal)) {
+          all_states2 <- c(all_states2, paste0(pool_init_states[i], letters_conceal[j]))
+        }
+      }
+      indices <- which(all_states %in% all_states2)
+    }
     pool_init_states <- -1 + indices
   }
 
@@ -131,7 +142,7 @@ secsse_sim <- function(lambdas,
 
   
 
-  initialState  <- res$initial_state
+  initialState  <- names(mus)[1 + res$initial_state]
   Ltable[, 1]   <- crown_age - Ltable[, 1] # simulation starts at 0,
                                            # not at crown age
   notmin1 <- which(Ltable[, 4] != -1)

--- a/R/secsse_sim.R
+++ b/R/secsse_sim.R
@@ -29,6 +29,8 @@ secsse_sim <- function(lambdas,
                        pool_init_states = NULL,
                        max_spec = 1e5,
                        min_spec = 2,
+                       max_species_extant = TRUE,
+                       tree_size_hist = FALSE,
                        conditioning = "obs_states",
                        non_extinction = TRUE,
                        verbose = FALSE,
@@ -88,6 +90,7 @@ secsse_sim <- function(lambdas,
                         qs,
                         crown_age,
                         max_spec,
+                        max_species_extant,
                         min_spec,
                         pool_init_states,
                         conditioning,
@@ -96,9 +99,13 @@ secsse_sim <- function(lambdas,
                         verbose,
                         max_tries,
                         seed,
-                        condition_vec)
+                        condition_vec,
+                        tree_size_hist)
 
   Ltable        <- res$ltable
+  
+  out_hist <- 0
+  if (tree_size_hist == TRUE) out_hist <- res$hist_tree_size
   
   if (sum(Ltable[, 4] == -1) < 2) {
     warning("crown lineages died out")
@@ -106,17 +113,20 @@ secsse_sim <- function(lambdas,
                 traits = 0,
                 extinct = res$tracker[2],
                 overshoot = res$tracker[3],
-                conditioning = res$tracker[4]))
+                conditioning = res$tracker[4],
+                size_hist = out_hist))
   }
 
   if (sum(res$tracker) >= max_tries) {
     warning("Couldn't simulate a tree in enough tries,
             try increasing max_tries")
+
     return(list(phy = "ds",
                 traits = 0,
                 extinct = res$tracker[2],
                 overshoot = res$tracker[3],
-                conditioning = res$tracker[4]))
+                conditioning = res$tracker[4],
+                size_hist = out_hist))
   }
 
   
@@ -163,7 +173,8 @@ secsse_sim <- function(lambdas,
                 overshoot = res$tracker[3],
                 conditioning = res$tracker[4],
                 event_counter = res$event_counter,
-                extinct_draw = res$extinct_draw))
+                extinct_draw = res$extinct_draw,
+                size_hist = out_hist))
   } else {
     warning("simulation did not meet minimal requirements")
     return(list(phy = "ds",
@@ -172,6 +183,7 @@ secsse_sim <- function(lambdas,
                 overshoot = res$tracker[3],
                 conditioning = res$tracker[4],
                 event_counter = res$event_counter,
-                extinct_draw = res$extinct_draw))
+                extinct_draw = res$extinct_draw,
+                size_hist = out_hist))
   }
 }

--- a/R/secsse_utils.R
+++ b/R/secsse_utils.R
@@ -466,7 +466,7 @@ check_input <- function(traits,
 
     check_tree(phy, is_complete_tree)
 
-    check_traits(traits, sampling_fraction)
+    # check_traits(traits, sampling_fraction)
 }
 
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,17 +1,20 @@
 citHeader("To cite secsse in publications use:")
 
-citEntry(
-  entry    = "Article",
-  title    = "Detecting the Dependence of Diversification on Multiple Traits from Phylogenetic Trees and Trait Data",
-  author   = "Leonel Herrera-Alsina, Paul van Els, Rampal S. Etienne",
-  journal  = "Systematic Biology",
-  year     = 2019,
-  volume   = 68,
-  number   = 2,
-  pages    = "317-328",
-  url      = "https://academic.oup.com/sysbio/article/68/2/317/5107025",
-  doi      = "10.1093/sysbio/syy057",
-  textVersion = "Leonel Herrera-Alsina, Paul van Els and Rampal S. Etienne, Detecting the Dependence of Diversification on Multiple Traits from Phylogenetic Trees and Trait Data, Systematic Biology, Volume 68, Issue 2, March 2019, Pages 317–328, https://doi.org/10.1093/sysbio/syy057",
-  footer   = "secsse is continually being developed, so you may also want to cite its version number (found with 'library(help = secsse)' or 'packageVersion(\"secsse\")')."
-)
+bibentry("Article",
+         title = "Detecting the Dependence of Diversification on Multiple Traits from Phylogenetic Trees and Trait Data",
+         author = c(person("Leonel", "Herrera Alsina",
+                           comment = c(ORCID = "0000-0003-0474-3592"),
+                           email = "leonelhalsina@gmail.com"),
+                    person("Paul", "van Els",
+                           email = "paulvanels@gmail.com",
+                           comment = c(ORCID = "0000-0002-9499-8873")),
+                    person("Rampal", "S. Etienne",
+                           email = "r.s.etienne@rug.nl",
+                           comment = c(ORCID = "0000-0003-2142-7612"))),
+         journal = "Systematic Biology",
+         year = "2019",
+         volume = "68",
+         number = "2",
+         pages = "317--328",
+         doi = "10.1093/sysbio/syy057")
 

--- a/man/default_params_doc.Rd
+++ b/man/default_params_doc.Rd
@@ -64,7 +64,12 @@ default_params_doc(
   params,
   param_posit,
   ml_pars,
-  mu_vector
+  mu_vector,
+  max_spec,
+  min_spec,
+  max_species_extant,
+  tree_size_hist,
+  optimmethod
 )
 }
 \arguments{

--- a/man/default_params_doc.Rd
+++ b/man/default_params_doc.Rd
@@ -270,6 +270,11 @@ against generating extremely large trees).}
 
 \item{min_spec}{Minimum number of species in the tree.}
 
+\item{max_species_extant}{Should the maximum number of species be counted in
+the reconstructed tree (if TRUE) or in the complete tree (if FALSE).}
+
+\item{tree_size_hist}{if TRUE, returns a vector of all found tree sizes.}
+
 \item{optimmethod}{A string with method used for optimization. Default is
 \code{"subplex"}. Alternative is \code{"simplex"} and it shouldn't be used in normal
 conditions (only for debugging). Both are called from \code{\link[DDD:optimizer]{DDD::optimizer()}},

--- a/man/secsse_sim.Rd
+++ b/man/secsse_sim.Rd
@@ -13,6 +13,8 @@ secsse_sim(
   pool_init_states = NULL,
   max_spec = 1e+05,
   min_spec = 2,
+  max_species_extant = TRUE,
+  tree_size_hist = FALSE,
   conditioning = "obs_states",
   non_extinction = TRUE,
   verbose = FALSE,
@@ -43,6 +45,11 @@ tree is not conditioned on this number, but that this is a safeguard
 against generating extremely large trees).}
 
 \item{min_spec}{Minimum number of species in the tree.}
+
+\item{max_species_extant}{Should the maximum number of species be counted in
+the reconstructed tree (if TRUE) or in the complete tree (if FALSE).}
+
+\item{tree_size_hist}{if TRUE, returns a vector of all found tree sizes.}
 
 \item{conditioning}{can be \code{"obs_states"}, \code{"true_states"} or \code{"none"}, the
 tree is simulated until one is generated that contains all observed states

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -74,8 +74,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // secsse_sim_cpp
-Rcpp::List secsse_sim_cpp(const std::vector<double>& m_R, const Rcpp::List& lambdas_R, const Rcpp::NumericMatrix& q_R, double max_time, double max_species, double min_species, const std::vector<double>& init_states, std::string condition, int num_concealed_states, bool non_extinction, bool verbose, int max_tries, int seed, const std::vector<double>& conditioning_vec);
-RcppExport SEXP _secsse_secsse_sim_cpp(SEXP m_RSEXP, SEXP lambdas_RSEXP, SEXP q_RSEXP, SEXP max_timeSEXP, SEXP max_speciesSEXP, SEXP min_speciesSEXP, SEXP init_statesSEXP, SEXP conditionSEXP, SEXP num_concealed_statesSEXP, SEXP non_extinctionSEXP, SEXP verboseSEXP, SEXP max_triesSEXP, SEXP seedSEXP, SEXP conditioning_vecSEXP) {
+Rcpp::List secsse_sim_cpp(const std::vector<double>& m_R, const Rcpp::List& lambdas_R, const Rcpp::NumericMatrix& q_R, double max_time, double max_species, bool max_species_extant, double min_species, const std::vector<double>& init_states, std::string condition, int num_concealed_states, bool non_extinction, bool verbose, int max_tries, int seed, const std::vector<double>& conditioning_vec, bool return_tree_size_hist);
+RcppExport SEXP _secsse_secsse_sim_cpp(SEXP m_RSEXP, SEXP lambdas_RSEXP, SEXP q_RSEXP, SEXP max_timeSEXP, SEXP max_speciesSEXP, SEXP max_species_extantSEXP, SEXP min_speciesSEXP, SEXP init_statesSEXP, SEXP conditionSEXP, SEXP num_concealed_statesSEXP, SEXP non_extinctionSEXP, SEXP verboseSEXP, SEXP max_triesSEXP, SEXP seedSEXP, SEXP conditioning_vecSEXP, SEXP return_tree_size_histSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -84,6 +84,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type q_R(q_RSEXP);
     Rcpp::traits::input_parameter< double >::type max_time(max_timeSEXP);
     Rcpp::traits::input_parameter< double >::type max_species(max_speciesSEXP);
+    Rcpp::traits::input_parameter< bool >::type max_species_extant(max_species_extantSEXP);
     Rcpp::traits::input_parameter< double >::type min_species(min_speciesSEXP);
     Rcpp::traits::input_parameter< const std::vector<double>& >::type init_states(init_statesSEXP);
     Rcpp::traits::input_parameter< std::string >::type condition(conditionSEXP);
@@ -93,7 +94,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type max_tries(max_triesSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
     Rcpp::traits::input_parameter< const std::vector<double>& >::type conditioning_vec(conditioning_vecSEXP);
-    rcpp_result_gen = Rcpp::wrap(secsse_sim_cpp(m_R, lambdas_R, q_R, max_time, max_species, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec));
+    Rcpp::traits::input_parameter< bool >::type return_tree_size_hist(return_tree_size_histSEXP);
+    rcpp_result_gen = Rcpp::wrap(secsse_sim_cpp(m_R, lambdas_R, q_R, max_time, max_species, max_species_extant, min_species, init_states, condition, num_concealed_states, non_extinction, verbose, max_tries, seed, conditioning_vec, return_tree_size_hist));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -102,7 +104,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_secsse_eval_cpp", (DL_FUNC) &_secsse_eval_cpp, 12},
     {"_secsse_calc_ll_cpp", (DL_FUNC) &_secsse_calc_ll_cpp, 12},
     {"_secsse_ct_condition_cpp", (DL_FUNC) &_secsse_ct_condition_cpp, 9},
-    {"_secsse_secsse_sim_cpp", (DL_FUNC) &_secsse_secsse_sim_cpp, 14},
+    {"_secsse_secsse_sim_cpp", (DL_FUNC) &_secsse_secsse_sim_cpp, 16},
     {NULL, NULL, 0}
 };
 

--- a/src/secsse_sim.cpp
+++ b/src/secsse_sim.cpp
@@ -77,6 +77,8 @@ num_mat_mat list_to_nummatmat(const Rcpp::List& lambdas_R) {
 
 }  // namespace util
 
+//' 
+
 // [[Rcpp::export]]
 Rcpp::List secsse_sim_cpp(const std::vector<double>& m_R,
                           const Rcpp::List& lambdas_R,
@@ -129,7 +131,10 @@ Rcpp::List secsse_sim_cpp(const std::vector<double>& m_R,
         tracker[ sim.run_info ]++;
       }
     } else { // if not reached minimum size
-      tracker[ 5 ]++;
+      if (sim.run_info == extinct) tracker[extinct]++;
+      else {
+        tracker[ 5 ]++;
+      }
     }
     
     if (verbose) {

--- a/src/secsse_sim.cpp
+++ b/src/secsse_sim.cpp
@@ -45,21 +45,6 @@ void vector_to_numericmatrix(const std::vector< std::vector< double >>& v,
   return;
 }
 
-
-void list_to_vector(const Rcpp::ListOf<Rcpp::NumericMatrix>& l,
-                    std::vector< std::vector< std::vector<double >>>* v) {
-  size_t n = l.size();
-  (*v) = std::vector< std::vector< std::vector<double>>>(n);
-  for (size_t i = 0; i < n; ++i) {
-    std::vector< std::vector< double >> entry;
-    Rcpp::NumericMatrix temp = l[i];
-    util::numericmatrix_to_vector(temp, &entry);
-    (*v).push_back(entry);
-  }
-  return;
-}
-
-
 num_mat_mat list_to_nummatmat(const Rcpp::List& lambdas_R) {
   num_mat_mat out(lambdas_R.size());
   for (int m = 0; m < lambdas_R.size(); ++m) {

--- a/src/secsse_sim.cpp
+++ b/src/secsse_sim.cpp
@@ -115,7 +115,7 @@ Rcpp::List secsse_sim_cpp(const std::vector<double>& m_R,
   while (true) {
     sim.run();
     cnt++;
-    sim.update_tree_size_hist(&tree_size_hist[cnt]);
+    if (return_tree_size_hist) sim.update_tree_size_hist(&tree_size_hist[cnt]);
     
     if (sim.num_species() >= min_species) {
       sim.check_conditioning(condition,

--- a/src/secsse_sim.h
+++ b/src/secsse_sim.h
@@ -549,7 +549,7 @@ struct secsse_sim {
 
     for (const auto& i : L.data_) {
       int trait = static_cast<int>(i.get_trait());
-      if (num_concealed_states > 0) trait %= num_concealed_states;
+      if (num_concealed_states > 0) trait = trait % num_concealed_states;
       focal_traits[trait]++;
     }
     

--- a/src/secsse_sim.h
+++ b/src/secsse_sim.h
@@ -262,6 +262,7 @@ struct secsse_sim {
   const size_t max_spec;
   const std::vector<double> init_states;
   const bool non_extinction;
+  const bool max_spec_extant;
   
   finish_type run_info;
   int init_state;
@@ -272,6 +273,7 @@ struct secsse_sim {
              const num_mat& q,
              double mt,
              size_t max_s,
+             bool max_s_e,
              const std::vector<double>& init,
              const bool& ne,
              int seed) :
@@ -281,6 +283,7 @@ struct secsse_sim {
              max_spec(max_s),
              init_states(init),
              non_extinction(ne),
+             max_spec_extant(max_s_e),
              run_info(not_run_yet),
              t(0.0)
               {
@@ -326,8 +329,15 @@ struct secsse_sim {
         run_info = extinct;
         break;
       }
-      if (pop.size() >= max_spec) {
-        run_info = overshoot; break;
+      
+      if (max_spec_extant) {
+        if (pop.size() >= max_spec) {
+          run_info = overshoot; break;
+        }
+      } else {
+        if (L.data_.size() >= max_spec) {
+          run_info = overshoot; break;
+        }
       }
     }
   }
@@ -614,7 +624,15 @@ struct secsse_sim {
   }
 
   size_t num_species() {
-    return pop.size();
+    if (max_spec_extant) {
+      return pop.size();
+    } else {
+      return L.data_.size();
+    }
+  }
+  
+  size_t ltable_size() {
+    return L.data_.size();
   }
   
   num_mat extract_ltable() {
@@ -625,5 +643,19 @@ struct secsse_sim {
       extracted_ltable[i] = row;
     }
     return extracted_ltable;
+  }
+
+  void update_tree_size_hist(int* val) {
+    if (run_info == extinct) {
+      *val = 0;
+      return;
+    }
+
+    if (max_spec_extant) {
+       *val = pop.size();
+    } else {
+       *val = L.data_.size();
+    }
+    return;
   }
 };

--- a/tests/testthat/test_cla_secsse_ml.R
+++ b/tests/testthat/test_cla_secsse_ml.R
@@ -49,4 +49,15 @@ test_that("trying a short ML search: cla_secsse", {
   )
 
   testthat::expect_equal(model_R$ML, -16.1342246206186)
+  
+  # we have to translate to lambda matrices to test the following:
+  param_posit <- idparslist
+  param_posit[[1]] <- secsse::prepare_full_lambdas(traits,
+                                                   num_concealed_states,
+                                                   idparslist[[1]])
+  
+  found_pars <- secsse::extract_par_vals(param_posit,
+                                         model_R$MLpars)
+  testthat::expect_equal(length(found_pars),
+                         max(param_posit[[3]], na.rm = TRUE))
 })

--- a/tests/testthat/test_integration_methods.R
+++ b/tests/testthat/test_integration_methods.R
@@ -1,0 +1,45 @@
+test_that("loglik for different integrators", {
+  set.seed(42)
+  out <- DDD::dd_sim(pars = c(0.4, 0.1, 40), age = 15)
+  phy <- out$tes
+  traits <- sample(c(0, 1), ape::Ntip(phy), replace = TRUE)
+  b <- c(0.04, 0.04)  # lambda
+  d <- rep(0, 2)
+  userTransRate <- 0.2 # transition rate among trait states
+  num_concealed_states <- 2
+  sampling_fraction <- c(1, 1)
+  toCheck <- secsse::id_paramPos(traits, num_concealed_states)
+  toCheck[[1]][] <- b
+  toCheck[[2]][] <- d
+  toCheck[[3]][, ] <- userTransRate
+  diag(toCheck[[3]]) <- NA
+  root_state_weight <- "maddison_weights"
+  cond <- "noCondit"
+  
+  loglik1 <- as.numeric(secsse_loglik(parameter = toCheck,
+                                      phy = phy,
+                                      traits = traits,
+                                      num_concealed_states =
+                                        num_concealed_states,
+                                      cond = cond,
+                                      root_state_weight = root_state_weight,
+                                      sampling_fraction = sampling_fraction)
+  )
+  
+  for (integ_method in c("odeint::runge_kutta_cash_karp54", 
+                         "odeint::runge_kutta_fehlberg78", 
+                         "odeint::runge_kutta_dopri5", 
+                         "odeint::bulirsch_stoer",
+                         "odeint::runge_kutta4")) {
+    loglik2 <- as.numeric(secsse_loglik(parameter = toCheck,
+                                        phy = phy,
+                                        traits = traits,
+                                        num_concealed_states =
+                                          num_concealed_states,
+                                        cond = cond,
+                                        root_state_weight = root_state_weight,
+                                        sampling_fraction = sampling_fraction,
+                                        method = integ_method))
+    testthat::expect_equal(loglik1, loglik2)
+  }
+})  

--- a/tests/testthat/test_lambda_setup.R
+++ b/tests/testthat/test_lambda_setup.R
@@ -35,25 +35,6 @@ test_that("lambda setup", {
   }
 })
 
-test_that("q_matrix", {
-  q_mat <- matrix(data = NA, nrow = 2, ncol = 2)
-  q_mat[1, 2] <- 1
-  q_mat[2, 1] <- 2
-
-  # first, we test on a 2x2 matrix
-  for (dd in c(TRUE, FALSE)) {
-    q1 <- secsse::q_doubletrans(traits = c(1, 2),
-                                masterBlock = q_mat,
-                                diff.conceal = dd)
-
-    q2 <- secsse::expand_q_matrix(q_matrix = q_mat,
-                                  num_concealed_states = 2,
-                                  diff.conceal = dd)
-    v1 <- as.vector(q1)
-    v2 <- as.vector(q2)
-    testthat::expect_true(all.equal(v1, v2))
-  }
-})
 
 test_that("setup", {
   focal_matrix <-

--- a/tests/testthat/test_lambda_setup.R
+++ b/tests/testthat/test_lambda_setup.R
@@ -126,3 +126,17 @@ test_that("setup", {
                                    diff.conceal = TRUE)
   testthat::expect_equal(8, max(q_ETD, na.rm = TRUE))
 })
+
+
+test_that("test q_doubletrans", {
+  traits <- c(2, 0, 1, 0, 2, 0, 1, 2, 2, 0)
+  num_concealed_states <- 3
+  masterBlock <- matrix(5, ncol = 3, nrow = 3, byrow = TRUE)
+  diag(masterBlock) <- NA
+  a1 <- q_doubletrans(traits, masterBlock, diff.conceal = FALSE)
+  a2 <- q_doubletrans(traits, masterBlock, diff.conceal = TRUE)
+  
+  a1 <- unique(as.vector(a1))
+  a2 <- unique(as.vector(a2))
+  testthat::expect_gt(length(a2), length(a1))
+})

--- a/tests/testthat/test_secsse_sim.R
+++ b/tests/testthat/test_secsse_sim.R
@@ -182,7 +182,7 @@ test_that("test secsse_sim pool_init_states and complete tree", {
   
   mu_p <- secsse::fill_in(mus, pars)
   q_mat_p <- secsse::fill_in(q_mat, pars)
-  testthat::expect_output(
+
   focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
                                    mus = mu_p,
                                    qs = q_mat_p,
@@ -195,7 +195,7 @@ test_that("test secsse_sim pool_init_states and complete tree", {
                                    drop_extinct = FALSE,
                                    tree_size_hist = TRUE,
                                    verbose = FALSE)
-  )
+  
   testthat::expect_equal(length(focal_tree$phy$tip.label), 100)
   if (requireNamespace("geiger")) {
     vx <- geiger::is.extinct(focal_tree$phy)

--- a/tests/testthat/test_secsse_sim.R
+++ b/tests/testthat/test_secsse_sim.R
@@ -167,11 +167,22 @@ test_that("test secsse_sim pool_init_states and complete tree", {
                                    drop_extinct = FALSE)
   testthat::expect_true(focal_tree$initialState %in% c("0A", "1B"))
   
+  focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
+                                   mus = mu_p,
+                                   qs = q_mat_p,
+                                   crown_age = 10,
+                                   num_concealed_states = 2,
+                                   pool_init_states = c("0"),
+                                   max_spec = 100,
+                                   seed = 21,
+                                   drop_extinct = FALSE)
+  testthat::expect_true(focal_tree$initialState %in% c("0A", "0B"))
   
   pars <- c(0.5, 0.3, 0.2, 0.1, 0.1)
-  # lambda_p <- secsse::fill_in(lambda_list, pars)
+  
   mu_p <- secsse::fill_in(mus, pars)
   q_mat_p <- secsse::fill_in(q_mat, pars)
+  testthat::expect_output(
   focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
                                    mus = mu_p,
                                    qs = q_mat_p,
@@ -181,11 +192,15 @@ test_that("test secsse_sim pool_init_states and complete tree", {
                                    min_spec = 99,
                                    max_species_extant = FALSE,
                                    seed = 21,
-                                   drop_extinct = FALSE)
+                                   drop_extinct = FALSE,
+                                   tree_size_hist = TRUE,
+                                   verbose = FALSE)
+  )
   testthat::expect_equal(length(focal_tree$phy$tip.label), 100)
   if (requireNamespace("geiger")) {
     vx <- geiger::is.extinct(focal_tree$phy)
     testthat::expect_true(length(vx) > 0)
   }
+  testthat::expect_gt(length(focal_tree$size_hist), 0)
 })
                       

--- a/tests/testthat/test_secsse_sim.R
+++ b/tests/testthat/test_secsse_sim.R
@@ -128,3 +128,63 @@ test_that("test secsse_sim 2", {
   }
 })
 
+
+test_that("test secsse_sim pool_init_states and complete tree", {
+  lambda_shift <- secsse::create_default_lambda_transition_matrix()
+  lambda_list <- secsse::create_lambda_list(transition_matrix = lambda_shift)
+  mus <- secsse::create_mu_vector(state_names = c(0, 1),
+                                  num_concealed_states = 2,
+                                  lambda_list = lambda_list)
+  q_mat <- secsse::create_default_shift_matrix(mu_vector = mus)
+  q_mat <- secsse::create_q_matrix(state_names = c(0, 1),
+                                   num_concealed_states = 2,
+                                   shift_matrix = q_mat)  
+  
+  pars <- c(0.5, 0.3, 0.7, 0.1, 0.1)
+  lambda_p <- secsse::fill_in(lambda_list, pars)
+  mu_p <- secsse::fill_in(mus, pars)
+  q_mat_p <- secsse::fill_in(q_mat, pars)
+  
+  focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
+                                   mus = mu_p,
+                                   qs = q_mat_p,
+                                   crown_age = 10,
+                                   num_concealed_states = 2,
+                                   pool_init_states = c("0A"),
+                                   max_spec = 100,
+                                   seed = 21,
+                                   drop_extinct = FALSE)
+  testthat::expect_true(focal_tree$initialState == "0A")
+  
+  focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
+                                   mus = mu_p,
+                                   qs = q_mat_p,
+                                   crown_age = 10,
+                                   num_concealed_states = 2,
+                                   pool_init_states = c("0A", "1B"),
+                                   max_spec = 100,
+                                   seed = 21,
+                                   drop_extinct = FALSE)
+  testthat::expect_true(focal_tree$initialState %in% c("0A", "1B"))
+  
+  
+  pars <- c(0.5, 0.3, 0.2, 0.1, 0.1)
+  # lambda_p <- secsse::fill_in(lambda_list, pars)
+  mu_p <- secsse::fill_in(mus, pars)
+  q_mat_p <- secsse::fill_in(q_mat, pars)
+  focal_tree <- secsse::secsse_sim(lambdas = lambda_p,
+                                   mus = mu_p,
+                                   qs = q_mat_p,
+                                   crown_age = 10,
+                                   num_concealed_states = 2,
+                                   max_spec = 100,
+                                   min_spec = 99,
+                                   max_species_extant = FALSE,
+                                   seed = 21,
+                                   drop_extinct = FALSE)
+  testthat::expect_equal(length(focal_tree$phy$tip.label), 100)
+  if (requireNamespace("geiger")) {
+    vx <- geiger::is.extinct(focal_tree$phy)
+    testthat::expect_true(length(vx) > 0)
+  }
+})

--- a/tests/testthat/test_secsse_sim.R
+++ b/tests/testthat/test_secsse_sim.R
@@ -188,3 +188,4 @@ test_that("test secsse_sim pool_init_states and complete tree", {
     testthat::expect_true(length(vx) > 0)
   }
 })
+                      

--- a/tests/testthat/test_secsse_vs_cla_secsse.R
+++ b/tests/testthat/test_secsse_vs_cla_secsse.R
@@ -29,13 +29,13 @@ test_that("secsse gives the same result as cla_secsse", {
   
   num_modeled_traits <- ncol(q) / floor(num_concealed_states)
   
-  setting_calculation <- build_initStates_time(example_phy_GeoSSE,
-                                               traits,
-                                               num_concealed_states,
+  setting_calculation <- build_initStates_time(phy = example_phy_GeoSSE,
+                                               traits = traits,
+                                               num_concealed_states = num_concealed_states,
                                                sampling_fraction = c(1, 1, 1),
                                                is_complete_tree = FALSE,
-                                               mus,
-                                               num_modeled_traits,
+                                               mus = mus,
+                                               num_unique_traits = num_modeled_traits,
                                                first_time = TRUE)
   states <- setting_calculation$states
   d <- ncol(states) / 2
@@ -49,7 +49,7 @@ test_that("secsse gives the same result as cla_secsse", {
                                      num_concealed_states = 3,
                                      cond = "proper_cond",
                                      root_state_weight = "proper_weights",
-                                     sampling_fraction = c(1,1,1),
+                                     sampling_fraction = c(1, 1, 1),
                                      setting_calculation = setting_calculation,
                                      see_ancestral_states = FALSE,
                                      loglik_penalty = 0,

--- a/tests/testthat/test_secsse_vs_cla_secsse.R
+++ b/tests/testthat/test_secsse_vs_cla_secsse.R
@@ -1,0 +1,82 @@
+test_that("secsse gives the same result as cla_secsse", {
+  Sys.unsetenv("R_TESTS")
+  
+  utils::data("example_phy_GeoSSE", package = "secsse")
+  traits <- as.numeric(example_phy_GeoSSE$tip.state)
+  
+  lambdas <- list()
+  lambdas[[1]] <- matrix(0, ncol = 3, nrow = 3, byrow = TRUE)
+  lambdas[[2]] <- lambdas[[1]]
+  lambdas[[3]] <- lambdas[[1]]
+  lambdas[[1]][1, 1] <- 1.5
+  lambdas[[2]][2, 2] <- 0.5
+  lambdas[[3]][3, 3] <- 1
+  
+  mus <- c(0.7, 0.7, 0.7)
+  
+  q <- matrix(0, ncol = 3, nrow = 3, byrow = TRUE)
+  q[2, 1] <- 1.4
+  q[3, 1] <- 1.3
+  q[1, 2] <- 0.7
+  q[1, 3] <- 0.7
+  
+  parameter <- list()
+  parameter[[1]] <- lambdas
+  parameter[[2]] <- mus
+  parameter[[3]] <- q
+  
+  num_concealed_states <- 3
+  
+  num_modeled_traits <- ncol(q) / floor(num_concealed_states)
+  
+  setting_calculation <- build_initStates_time(example_phy_GeoSSE,
+                                               traits,
+                                               num_concealed_states,
+                                               sampling_fraction = c(1, 1, 1),
+                                               is_complete_tree = FALSE,
+                                               mus,
+                                               num_modeled_traits,
+                                               first_time = TRUE)
+  states <- setting_calculation$states
+  d <- ncol(states) / 2
+  new_states <- states[, c(1, 2, 3, 10, 11, 12)]
+  states <- new_states
+  setting_calculation$states <- states
+
+  cla_secsse_LL <- cla_secsse_loglik(parameter = parameter,
+                                     phy = example_phy_GeoSSE,
+                                     traits = traits,
+                                     num_concealed_states = 3,
+                                     cond = "proper_cond",
+                                     root_state_weight = "proper_weights",
+                                     sampling_fraction = c(1,1,1),
+                                     setting_calculation = setting_calculation,
+                                     see_ancestral_states = FALSE,
+                                     loglik_penalty = 0,
+                                     is_complete_tree = FALSE,
+                                     num_threads = 1,
+                                     method = "odeint::bulirsch_stoer",
+                                     atol = 1e-8,
+                                     rtol = 1e-7)
+  
+  pars <- parameter
+  pars[[1]] <- c(lambdas[[1]][1, 1], lambdas[[2]][2, 2], lambdas[[3]][3, 3])
+  
+  secsse_LL <- secsse_loglik(parameter = pars,
+                             phy = example_phy_GeoSSE,
+                             traits = traits,
+                             num_concealed_states = num_concealed_states,
+                             cond = "proper_cond",
+                             root_state_weight = "proper_weights",
+                             sampling_fraction = c(1,1,1),
+                             setting_calculation = setting_calculation,
+                             see_ancestral_states = FALSE,
+                             loglik_penalty = 0,
+                             is_complete_tree = FALSE,
+                             num_threads = 1,
+                             atol = 1e-8,
+                             rtol = 1e-7,
+                             method = "odeint::bulirsch_stoer")
+  
+  testthat::expect_equal(secsse_LL, cla_secsse_LL,tolerance = 1e-5)
+})


### PR DESCRIPTION
Adds @thijsjanzen's additions and bugfixes.
Fixes zenodo import (hopefully).

# v3.0.1

Version 3.0.1 patches some inaccuracies in simulation functions, and
deprecates expand_q_matrix, as this was making some incorrect
assumptions.

## Breaking changes

-   The function expand_q_matrix is now deprecated, please use
    q_doubletrans

## Minor changes

-   Added conditioning of simulation of complete trees on complete tree
    size
-   Fixed some issues with setting `pool_init_states`
-   Added option to return a histogram of simulated tree sizes, across
    all successful and failed trees.