### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
  diversitree,
  phytools,
  testthat,
+ subplex,
  knitr,
  rmarkdown
 LinkingTo: 


### PR DESCRIPTION
add 'subplex' to 'suggests', to (hopefully) fix NOTE on fedora.